### PR TITLE
bug resolved

### DIFF
--- a/Assets/Scripts/Level.cs
+++ b/Assets/Scripts/Level.cs
@@ -71,6 +71,7 @@ public class Level : MonoBehaviour
         abilitiesSpawned = 0;
         abilitiesSpawnTimerMax = 5f;
         abilitiesSpawnTimer = 0f;
+
     }
     private void Start()
     {
@@ -276,6 +277,15 @@ public class Level : MonoBehaviour
     public int GetPipePassed()
     {
         return pipesPassedCount;
+    }
+
+ 
+    //make the spawning faster/slower
+    public void ScaleSpawnerTimers(float scale)
+    {
+        abilitiesSpawnTimerMax = abilitiesSpawnTimerMax / scale;
+        pipeSpawnTimerMax = pipeSpawnTimerMax / scale;
+        Debug.Log("The value of pipeSpawnTimerMax : " + pipeSpawnTimerMax);
     }
 
 

--- a/Assets/Scripts/handlers/GameHandler.cs
+++ b/Assets/Scripts/handlers/GameHandler.cs
@@ -7,12 +7,23 @@ using CodeMonkey.Utils;
 public class GameHandler : MonoBehaviour
 {
 
+    public static float _objectsMovingSpeed = 30f;
     [SerializeField]
-    public static float OBJECTS_MOVING_SPEED { get; set; } = 30f;
+    public static float OBJECTS_MOVING_SPEED { get
+        {
+            return _objectsMovingSpeed;
+        }
+        set
+        {         
+            float ratio = value / _objectsMovingSpeed;
+            Level.GetInstance().ScaleSpawnerTimers(ratio);
+            _objectsMovingSpeed = value;
+            
+        } }
 
     private void Awake()
     {
-        OBJECTS_MOVING_SPEED = 30f;
+        _objectsMovingSpeed = 30f;
     }
 
 


### PR DESCRIPTION
Previously, spawning timers remained unchanged when the game speed was adjusted, leading to inconsistent difficulty levels. (E.g. fewer pipes were generated when the game speed increased)